### PR TITLE
おみくじAPIの作成と結果ページの実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.2.22",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "swr": "^2.3.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1286,6 +1287,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/doctrine": {
@@ -4331,6 +4341,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
+      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -4545,6 +4568,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.2.22",
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.2.22"
+    "swr": "^2.3.0"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",
-    "eslint-config-next": "14.2.22"
+    "eslint-config-next": "14.2.22",
+    "typescript": "^5"
   }
 }

--- a/src/pages/api/lottery.ts
+++ b/src/pages/api/lottery.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type LotteryResult = {
+  result: string;
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<LotteryResult>
+) {
+  const fortune = Math.random();
+  let result = "unlucky";
+  if (fortune >= 0.5) {
+    result = "lucky";
+  }
+  if (fortune >= 0.75) {
+    result = "very lucky";
+  }
+  res.status(200).json({ result });
+}

--- a/src/pages/lottery.tsx
+++ b/src/pages/lottery.tsx
@@ -1,0 +1,16 @@
+import { NextPage } from "next";
+import { LotteryResult } from "./api/lottery";
+import useSWR from "swr";
+
+const fetcher = (url: string): Promise<LotteryResult> =>
+  fetch(url).then((response) => response.json());
+
+const Lottery: NextPage<{}> = () => {
+  const { data: lottery, error } = useSWR("/api/lottery", fetcher);
+  return (
+    <>
+      <p>おみくじ結果: {lottery?.result}</p>
+    </>
+  );
+};
+export default Lottery;


### PR DESCRIPTION
概要:
- おみくじAPIの作成と、その結果を表示するフロントエンドページを実装しました。

変更内容:
- `src/pages/api/lottery.ts`: APIエンドポイント `/api/lottery` を作成。
- `src/pages/lottery.tsx`: APIの結果を取得し、表示するページを作成。
- SWR を導入し、APIから非同期でデータを取得。

動作確認:
- `/api/lottery` と `/lottery` ページが正しく動作することをローカル環境で確認しました。